### PR TITLE
Define `cb` in Gulp "serve" task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,7 @@ var gulp = require('gulp');
 var $ = require('gulp-load-plugins')();
 var browserSync = require('browser-sync');
 
-gulp.task('serve', function () {
+gulp.task('serve', function (cb) {
   var started = false;
 
   return $.nodemon({


### PR DESCRIPTION
`cb` wasn't defined within the "serve" task previously.